### PR TITLE
Updates substring manipulation

### DIFF
--- a/lib/flasher.sh
+++ b/lib/flasher.sh
@@ -95,7 +95,8 @@ _create_zip_option() {
         cp "${OPTARG}" "${ANYKERNEL_DIR}"
 
         # CD to AnyKernel folder
-        cd "${ANYKERNEL_DIR}" || (_error "AnyKernel dir not found !"; _exit)
+        cd "${ANYKERNEL_DIR}" || \
+            (_error "AnyKernel dir not found !"; _exit)
 
         # Create flashable zip
         zip -r9 "${OPTARG##*/}-${DATE}-${TIME}.zip" ./* \
@@ -111,7 +112,8 @@ _create_zip_option() {
         if [[ ! -d ${DIR}/builds/default ]]; then
             mkdir "${DIR}/builds/default"
         fi
-        mv "${OPTARG##*/}-${DATE}_${TIME}-signed.zip" "${DIR}/builds/default"
+        mv "${OPTARG##*/}-${DATE}_${TIME}-signed.zip" \
+            "${DIR}/builds/default"
 
         # Back to script dir
         _clean_anykernel

--- a/lib/prompter.sh
+++ b/lib/prompter.sh
@@ -94,7 +94,7 @@ _ask_for_cores() {
     case ${CONFIRM} in
         n|N|no|No|NO)
             until [[ ${CORES} =~ ^[1-9]{1}[0-9]{0,1}$ ]]; do
-                _prompt "Enter amount of cores to use :"
+                _prompt "Enter the amount of cores to use :"
                 read -r CORES
             done
             ;;

--- a/lib/requirements.sh
+++ b/lib/requirements.sh
@@ -49,10 +49,10 @@ _install_dependencies() {
     # Install missing dependencies
     if [[ ${PM[3]} ]]; then
         for PACKAGE in "${DEPENDENCIES[@]}"; do
-            if ! which "${PACKAGE//llvm/llvm-ar}" &>/dev/null; then
+            if ! which "${PACKAGE/llvm/llvm-ar}" &>/dev/null; then
                 _ask_for_install_pkg
                 if [[ ${INSTALL_PKG} == True ]]; then
-                    eval "${PM[0]//_/}" "${PM[1]}" \
+                    eval "${PM[0]/_/}" "${PM[1]}" \
                         "${PM[2]}" "${PM[3]}" "${PACKAGE}"
                 fi
             fi

--- a/lib/telegram.sh
+++ b/lib/telegram.sh
@@ -83,13 +83,13 @@ _send_file_option() {
 _telegram_status_msg() {
     export STATUS_MSG="
 
-<b>Android Device :</b>  <code>${CODENAME/_/-}</code>
-<b>Kernel Version :</b>  <code>v${LINUX_VERSION/_/-}</code>
-<b>Kernel Variant :</b>  <code>${KERNEL_VARIANT/_/-}</code>
-<b>Host Builder :</b>  <code>${BUILDER/_/-}</code>
-<b>Host Core Count :</b>  <code>${CORES}</code>
-<b>Compiler Used :</b>  <code>${COMPILER/_/-}</code>
-<b>Operating System :</b>  <code>${HOST/_/-}</code>
-<b>Build Tag :</b>  <code>${TAG/_/-}</code>
-<b>Android :</b>  <code>${PLATFORM_VERSION/_/-}</code>"
+<b>Android Device :</b>  <code>${CODENAME//_/-}</code>
+<b>Kernel Version :</b>  <code>v${LINUX_VERSION//_/-}</code>
+<b>Kernel Variant :</b>  <code>${KERNEL_VARIANT//_/-}</code>
+<b>Host Builder :</b>  <code>${BUILDER//_/-}</code>
+<b>Host Core Count :</b>  <code>${CORES//_/-}</code>
+<b>Compiler Used :</b>  <code>${COMPILER//_/-}</code>
+<b>Operating System :</b>  <code>${HOST//_/-}</code>
+<b>Build Tag :</b>  <code>${TAG//_/-}</code>
+<b>Android :</b>  <code>${PLATFORM_VERSION//_/-}</code>"
 }


### PR DESCRIPTION
Prevent Telegram API 429 caused by underscores in messages: replace all occurencies.
Which: prevent unknow binary, llvm should be replaced by llvm-ar.
Termux install cmd replacement: ability to run sudo command as root has been disabled permanently for safety purposes.
