### PR TITLE
Jekyll: Use of hypertext link for source code

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -74,4 +74,4 @@ Then you should be able to `git pull upstream main` from your main branch and ei
 
 * Codiga Code Review: [link](https://app.codiga.io/public/project/23638/Neternels-Builder/dashboard)
 * Codefactor Code Review: [link](https://www.codefactor.io/repository/github/grm34/neternels-builder)
-* Code Source: [https://github.com/grm34/Neternels-Builder](https://kernel-builder.com)
+* Code Source: [github](https://kernel-builder.com)


### PR DESCRIPTION
Signed-off-by: grm34 <jerem.pardo@tutanota.com>