### PR TITLE
ZMB: Sleep instead of exit on error (Make Clean)

### DIFF
--- a/src/main.sh
+++ b/src/main.sh
@@ -208,7 +208,7 @@ if [[ $MAKE_CLEAN == True ]]
 then
     _make_clean
     _make_mrproper
-    _check rm -rf "$OUT_DIR"
+    rm -rf "$OUT_DIR" || sleep 0.1
 fi
 
 # Make defconfig


### PR DESCRIPTION
Accept RM error in case of make clean request while no previous build.

Signed-off-by: grm34 <jerem.pardo@tutanota.com>