### PR TITLE
ZMB: Auto define CROSS_COMPILE in Makefile (TC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@ Dependencies will be prompted to install or you can manually install them.
 
 ## Warning
 
-ZMB is a tool to facilitate the compilation of the Android kernel, it does not modify the source and does not adds possible modifications that must be made to Makefile, in most cases at least (commenting on these lines is usually sufficient, being declared by ZMB) :
+ZMB is a tool to facilitate the compilation of the Android kernel, it does not touch at the source and does not adds possible modifications that must be made to Makefile, except the setting of CROSS_COMPILE like this :
 
     # Proton-Clang / Proton-GCC
-    CROSS_COMPILE = <path_to>/ZenMaxBuilder/toolchains/proton_clang/bin/aarch64-linux-gnu-
+    CROSS_COMPILE = aarch64-linux-gnu-
 
     # Eva-GCC
-    CROSS_COMPILE = <path_to>/ZenMaxBuilder/toolchains/gcc_arm64/bin/aarch64-elf-
+    CROSS_COMPILE = aarch64-elf-
 
 Sources are often configured for a specific compilation (vendor, firmware, modules) and little changes are often necessary. For a kernel building support, you can ask for help on [Telegram](https://t.me/ZenMaxBuilder).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,13 +66,13 @@ Dependencies will be prompted to install or you can manually install them.
 
 ## Warning
 
-ZMB is a tool to facilitate the compilation of the Android kernel, it does not modify the source and does not adds possible modifications that must be made to Makefile, in most cases at least (commenting on these lines is usually sufficient, being declared by ZMB) :
+ZMB is a tool to facilitate the compilation of the Android kernel, it does not touch at the source and does not adds possible modifications that must be made to Makefile, except the setting of CROSS_COMPILE like this :
 
     # Proton-Clang / Proton-GCC
-    CROSS_COMPILE = <path_to>/ZenMaxBuilder/toolchains/proton_clang/bin/aarch64-linux-gnu-
+    CROSS_COMPILE = aarch64-linux-gnu-
 
     # Eva-GCC
-    CROSS_COMPILE = <path_to>/ZenMaxBuilder/toolchains/gcc_arm64/bin/aarch64-elf-
+    CROSS_COMPILE = aarch64-elf-
 
 Sources are often configured for a specific compilation (vendor, firmware, modules) and little changes are often necessary. For a kernel building support, you can ask for help on [Telegram](https://t.me/ZenMaxBuilder).
 

--- a/lang/en.cfg
+++ b/lang/en.cfg
@@ -33,6 +33,8 @@ MSG_ERR_LINE="Line"
 MSG_ERR_FROM="From"
 MSG_EXIT="Exiting ZenMaxBuilder"
 MSG_NOTE_CLEAN_AK3="Cleaning AnyKernel repository"
+MSG_WARN_CC="CROSS_COMPILE may not be set correctly in Makefile"
+MSG_NOTE_CC="Kernel Makefile CROSS_COMPILE Verification"
 
 # src/flasher.sh
 # ==============
@@ -95,6 +97,7 @@ MSG_SELECT_TC="Select the Toolchain Compiler to use"
 MSG_ERR_SELECT="invalid selection (use number)"
 MSG_ASK_DEV="Enter android device codename (e.g. X00TD)"
 MSG_ERR_DEV="invalid device codename"
+MSG_ASK_CC="Do you wish to set CROSS_COMPILE in Makefile for"
 MSG_ASK_DEF="Select the defconfig file to use"
 MSG_ASK_CONF="Do you wish to edit Kernel with menuconfig"
 MSG_ASK_CPU="Do you wish to use all available CPU Cores"

--- a/lang/es.cfg
+++ b/lang/es.cfg
@@ -33,6 +33,8 @@ MSG_ERR_LINE="Línea"
 MSG_ERR_FROM="Desde"
 MSG_EXIT="Salir de ZenMaxBuilder"
 MSG_NOTE_CLEAN_AK3="Limpieza del repositorio de AnyKernel"
+MSG_WARN_CC="CROSS_COMPILE puede no estar configurado en el Makefile"
+MSG_NOTE_CC="Kernel Makefile CROSS_COMPILE Verificación"
 
 # src/flasher.sh
 # ==============
@@ -95,6 +97,7 @@ MSG_SELECT_TC="Seleccione el compilador a utilizar"
 MSG_ERR_SELECT="selección no válida (usar número)"
 MSG_ASK_DEV="Introduzca el dispositivo android (p.e: X00TD)"
 MSG_ERR_DEV="dispositivo android inválido"
+MSG_ASK_CC="Quieres establecer CROSS_COMPILE en el Makefile para"
 MSG_ASK_DEF="Seleccione el archivo defconfig a utilizar"
 MSG_ASK_CONF="Quieres editar el Kernel con menuconfig"
 MSG_ASK_CPU="Quieres utilizar todos los CPU núcleos disponibles"

--- a/lang/fr.cfg
+++ b/lang/fr.cfg
@@ -33,6 +33,8 @@ MSG_ERR_LINE="Ligne"
 MSG_ERR_FROM="Depuis"
 MSG_EXIT="Sortie de ZenMaxBuilder"
 MSG_NOTE_CLEAN_AK3="Nettoyage du dépôt AnyKernel"
+MSG_WARN_CC="CROSS_COMPILE peut-être mal définit dans Makefile"
+MSG_NOTE_CC="Kernel Makefile CROSS_COMPILE Vérification"
 
 # src/flasher.sh
 # ==============
@@ -95,6 +97,7 @@ MSG_SELECT_TC="Sélectionnez le Compiler à utiliser"
 MSG_ERR_SELECT="sélection invalide (utilisez un nombre)"
 MSG_ASK_DEV="Entrez le nom de code du téléphone (ex: X00TD)"
 MSG_ERR_DEV="code de téléphone invalide"
+MSG_ASK_CC="Voulez-vous définir CROSS_COMPILE dans Makefile pour"
 MSG_ASK_DEF="Sélectionner le fichier defconfig à utiliser"
 MSG_ASK_CONF="Voulez-vous éditer le noyau avec menuconfig"
 MSG_ASK_CPU="Voulez-vous utiliser tous les Coeurs du CPU"

--- a/src/main.sh
+++ b/src/main.sh
@@ -191,6 +191,7 @@ _ask_for_kernel_dir
 _ask_for_defconfig
 _ask_for_menuconfig
 _ask_for_toolchain
+_get_cross_compile
 _ask_for_cores
 
 # Install and clone requirements

--- a/src/manager.sh
+++ b/src/manager.sh
@@ -114,8 +114,8 @@ _edit_makefile_cross_compile() {
 # Get CROSS_COMPILE and edit Makefile
 _get_cross_compile() {
     _note "$MSG_NOTE_CC"
-    cat "${KERNEL_DIR}/Makefile" | \
-        grep CROSS_COMPILE | grep -v "ifneq\|export\|#"
+    grepcc=$(grep CROSS_COMPILE "${KERNEL_DIR}/Makefile")
+    echo "$grepcc" | grep -v "ifneq\|export\|#"
     _ask_for_edit_cross_compile
     case $COMPILER in
         "$PROTON_CLANG_NAME")

--- a/src/manager.sh
+++ b/src/manager.sh
@@ -102,6 +102,38 @@ _get_build_logs() {
 }
 
 
+# Edit CROSS_COMPILE in Makefile
+_edit_makefile_cross_compile() {
+    cc=${ccompiler/CROSS_COMPILE=/}
+    _check sed -i \
+        "s/CROSS_COMPILE.*?=.*/CROSS_COMPILE ?= ${cc}/g" \
+        "${KERNEL_DIR}/Makefile"
+}
+
+
+# Get CROSS_COMPILE and edit Makefile
+_get_cross_compile() {
+    _note "$MSG_NOTE_CC"
+    cat "${KERNEL_DIR}/Makefile" | \
+        grep CROSS_COMPILE | grep -v "ifneq\|export\|#"
+    _ask_for_edit_cross_compile
+    case $COMPILER in
+        "$PROTON_CLANG_NAME")
+            ccompiler=${PROTON_CLANG_OPTIONS[2]}
+            ;;
+        "$PROTON_GCC_NAME")
+            ccompiler=${PROTON_GCC_OPTIONS[3]}
+            ;;
+        "$EVA_GCC_NAME")
+            ccompiler=${EVA_GCC_OPTIONS[3]}
+    esac
+    if [[ $EDIT_CC == True ]]
+    then
+        _edit_makefile_cross_compile
+    fi
+}
+
+
 # CD to specified DIR
 # ===================
 #   $1 = location

--- a/src/prompter.sh
+++ b/src/prompter.sh
@@ -133,6 +133,21 @@ _ask_for_toolchain() {
 }
 
 
+# Request to edit Makefile CROSS_COMPILE.
+# Validation checks are not needed here.
+_ask_for_edit_cross_compile() {
+    _confirm "$MSG_ASK_CC $COMPILER ?" "[y/N]"
+    case $CONFIRM in
+        y|Y|yes|Yes|YES)
+            EDIT_CC=True
+            ;;
+        *)
+            _note "$MSG_WARN_CC"
+            export EDIT_CC=False
+    esac
+}
+
+
 # Question to get the number of CPU cores to use.
 # Validation checks for a valid number corresponding
 # to the amount of available CPU cores (no limits here).


### PR DESCRIPTION
Automatic modification of CROSS_COMPILE in kernel Makefile to prevent misconfiguration or oversight by unsophisticated users (matching selected toolchain)

Signed-off-by: grm34 <jerem.pardo@tutanota.com>