### PR TITLE
Improves toolchain linker check (readelf)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@
 
 | File   | blank | comment | code |
 | :----- | ----: | ------: | ---: |
-| zmb.sh |   136 |     315 | 1205 |
+| zmb.sh |   136 |     315 | 1207 |
 
 ZMB has been coded largely on a smartphone, so the length of the lines is greatly reduced for better visibility to ensure the best support and maintenance, which explains such a large number of lines.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@
 
 | File   | blank | comment | code |
 | :----- | ----: | ------: | ---: |
-| zmb.sh |   136 |     315 | 1207 |
+| zmb.sh |   136 |     315 | 1208 |
 
 ZMB has been coded largely on a smartphone, so the length of the lines is greatly reduced for better visibility to ensure the best support and maintenance, which explains such a large number of lines.
 

--- a/etc/settings.cfg
+++ b/etc/settings.cfg
@@ -294,6 +294,7 @@ PROTON_DIR="proton-clang"
 PROTON_URL="https://github.com/grm34/proton-clang.git"
 PROTON_BRANCH="ZenMaxBuilder"
 PROTON_VERSION="proton-clang/lib/clang"
+PROTON_CHECK="proton-clang/bin/clang"
 
 # EVA GCC-ARM64
 # Fork of mvaisakh (updated every 15min)
@@ -306,6 +307,7 @@ EVA_ARM64_DIR="eva-arm64"
 EVA_ARM64_URL="https://github.com/grm34/gcc-arm64.git"
 EVA_ARM64_BRANCH="ZenMaxBuilder"
 EVA_ARM64_VERSION="eva-arm64/lib/gcc/aarch64-elf"
+EVA_ARM64_CHECK="eva-arm64/bin/aarch64-elf-gcc"
 
 # EVA GCC-ARM
 # Fork of mvaisakh (updated every 15min)
@@ -318,6 +320,7 @@ EVA_ARM_DIR="eva-arm"
 EVA_ARM_URL="https://github.com/grm34/gcc-arm.git"
 EVA_ARM_BRANCH="ZenMaxBuilder"
 EVA_ARM_VERSION="eva-arm/lib/gcc/arm-eabi"
+EVA_ARM_CHECK="eva-arm/bin/arm-eabi-gcc"
 
 # LOS GCC-ARM64
 # Fork of LineageOS (updated every 15min)
@@ -330,6 +333,7 @@ LOS_ARM64_DIR="los-arm64"
 LOS_ARM64_URL="https://github.com/grm34/android_prebuilts_gcc_linux-x86_aarch64_aarch64-linux-android-4.9.git"
 LOS_ARM64_BRANCH="ZenMaxBuilder"
 LOS_ARM64_VERSION="los-arm64/lib/gcc/aarch64-linux-android"
+LOS_ARM64_CHECK="los-arm64/bin/real-aarch64-linux-android-gcc"
 
 # LOS GCC-ARM
 # Fork of LineageOS (updated every 15min)
@@ -342,6 +346,7 @@ LOS_ARM_DIR="los-arm"
 LOS_ARM_URL="https://github.com/grm34/android_prebuilts_gcc_linux-x86_arm_arm-linux-androideabi-4.9.git"
 LOS_ARM_BRANCH="ZenMaxBuilder"
 LOS_ARM_VERSION="los-arm/lib/gcc/arm-linux-androideabi"
+LOS_ARM_CHECK="los-arm/bin/real-arm-linux-androideabi-gcc"
 
 # AOSP CLANG
 # The latest tag will always be used as default
@@ -354,6 +359,7 @@ AOSP_CLANG_DIR="aosp-clang"
 AOSP_CLANG_URL="https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86/+/refs/heads/master"
 AOSP_CLANG_BRANCH="master"
 AOSP_CLANG_VERSION="aosp-clang/AndroidVersion.txt"
+AOSP_CLANG_CHECK="aosp-clang/bin/clang-check"
 
 # LLVM ARM64
 # The latest tag will always be used as default
@@ -366,6 +372,7 @@ LLVM_ARM64_DIR="llvm-arm64"
 LLVM_ARM64_URL="https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/+refs"
 LLVM_ARM64_BRANCH="master"
 LLVM_ARM64_VERSION="llvm-arm64/AndroidVersion.txt"
+LLVM_ARM64_CHECK="llvm-arm64/bin/aarch64-linux-android-gcc-ar"
 
 # LLVM ARM
 # The latest tag will always be used as default
@@ -378,6 +385,7 @@ LLVM_ARM_DIR="llvm-arm"
 LLVM_ARM_URL="https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9/+refs"
 LLVM_ARM_BRANCH="master"
 LLVM_ARM_VERSION="llvm-arm/AndroidVersion.txt"
+LLVM_ARM_CHECK="llvm-arm/bin/arm-linux-androideabi-gcc-ar"
 
 # LINUX STABLE
 # To get the latest Linux Stable tag

--- a/src/zmb.sh
+++ b/src/zmb.sh
@@ -225,7 +225,7 @@ _confirm() {
   until [[ -z $confirm ]] \
       || [[ $confirm =~ ^(y|n|Y|N|yes|no|Yes|No|YES|NO) ]]; do
     _error "$MSG_ERR_CONFIRM"
-    _confirm_msg "$@"
+    _confirm "$@"
   done
 }
 

--- a/src/zmb.sh
+++ b/src/zmb.sh
@@ -1301,8 +1301,9 @@ _export_path_and_options() {
 _check_linker() {
   # ARG: $@ = toolchain check (from settings.cfg)
   for linker in "$@"; do
-    linker="$(readelf --all "$1" \
-      | grep -m 1 interpreter | awk -F ": " '{print $NF}')"
+    linker="$(readelf --program-headers "$1" \
+      | grep -m 1 -E "^\s*\[\w{1,}\s\w{1,}\s\w{1,}:\s" \
+      | awk -F ": " '{print $NF}')"
     linker="${linker/]}"
     if ! [[ -f $linker ]]; then
       _error warn "$MSG_WARN_LINKER ${red}${linker}$nc"

--- a/src/zmb.sh
+++ b/src/zmb.sh
@@ -1301,7 +1301,7 @@ _export_path_and_options() {
 _check_linker() {
   # ARG: $@ = toolchain check (from settings.cfg)
   for linker in "$@"; do
-    linker="$(readelf --program-headers "$1" \
+    linker="$(readelf --program-headers "$linker" \
       | grep -m 1 -E "^\s*\[\w{1,}\s\w{1,}\s\w{1,}:\s" \
       | awk -F ": " '{print $NF}')"
     linker="${linker/]}"


### PR DESCRIPTION
- Better way to specify the file to check in the settings.
- Better use `--program-headers` instead of `--all` (faster, cleaner...)
- Use regex > `readelf` output is displayed in user's language, so requesting a `grep
interpreter` to match the linker will fail on any non English OS...