### PR TITLE
MAIN: Improves `CROSS_COMPILE` management

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -14,7 +14,7 @@
 
 | File   | blank | comment | code |
 | :----- | ----: | ------: | ---: |
-| zmb.sh |   154 |     314 | 1364 |
+| zmb.sh |   154 |     314 | 1365 |
 
 ZMB has been coded largely on a smartphone, so the length of the lines is greatly reduced for better visibility to ensure the best support and maintenance, which explains such a large number of lines.
 

--- a/src/zmb.sh
+++ b/src/zmb.sh
@@ -451,9 +451,10 @@ _get_tc_version() {
 _get_android_platform_version() {
   # Grabs PLATFORM_VERSION from the kernel Makefile
   # Returns: $amv $ptv
-  amv="$(grep -m 1 "ANDROID_MAJOR_VERSION=" \
+  amv="$(grep -m 1 -E "ANDROID_MAJOR_VERSION(\s)?.*=" \
     "${KERNEL_DIR}/Makefile")"
-  ptv="$(grep -m 1 "PLATFORM_VERSION=" "${KERNEL_DIR}/Makefile")"
+  ptv="$(grep -m 1 -E "PLATFORM_VERSION(\s)?.*=" \
+    "${KERNEL_DIR}/Makefile")"
   amv="${amv/ANDROID_MAJOR_VERSION=}"
   ptv="${ptv/PLATFORM_VERSION=}"
 }
@@ -464,9 +465,9 @@ _get_cross_compile() {
   # Usage: _get_cross_compile "1" (use arg to bypass note)
   ! [[ $1 ]] && _note "$MSG_NOTE_CC"
   local cross cc
-  cross="$(grep -m 1 "^CROSS_COMPILE.*=" \
+  cross="$(grep -m 1 -E "^CROSS_COMPILE(\s)?.*=" \
     "${KERNEL_DIR}/Makefile")"
-  cc="$(grep -m 1 "^CC.*=" "${KERNEL_DIR}/Makefile")"
+  cc="$(grep -m 1 -E "^CC(\s)?.*=" "${KERNEL_DIR}/Makefile")"
   if [[ -z $cross ]] || [[ -z $cc ]]; then
     _error "$MSG_ERR_CC"; _exit 1
   else
@@ -562,17 +563,17 @@ _check_makefile() {
   local cross cc r1 r2 check1 check2
   cross="${TC_OPTIONS[1]/CROSS_COMPILE=}"
   cc="${TC_OPTIONS[3]/CC=}"
-  r1=("^CROSS_COMPILE\s.*=.*" "CROSS_COMPILE\ ?=\ ${cross}")
-  r2=("^CC\s.*=.*" "CC\ =\ ${cc}\ -I${KERNEL_DIR}")
-  check1="$(grep -m 1 "${r1[0]}" "${KERNEL_DIR}/Makefile")"
-  check2="$(grep -m 1 "${r2[0]}" "${KERNEL_DIR}/Makefile")"
+  r1=("^CROSS_COMPILE(\s)?.*=.*" "CROSS_COMPILE\ ?=\ ${cross}")
+  r2=("^CC(\s)?.*=.*" "CC\ =\ ${cc}\ -I${KERNEL_DIR}")
+  check1="$(grep -m 1 -E "${r1[0]}" "${KERNEL_DIR}/Makefile")"
+  check2="$(grep -m 1 -E "${r2[0]}" "${KERNEL_DIR}/Makefile")"
   if [[ -n ${check1##*"${cross}"*} ]] \
       || [[ -n ${check2##*"${cc}"*} ]]; then
     _warn "$MSG_WARN_CC"
     _ask_for_edit_cross_compile
     if [[ $EDIT_CC != False ]]; then
-      _check sed -i "s|${r1[0]}|${r1[1]}|g" "${KERNEL_DIR}/Makefile"
-      _check sed -i "s|${r2[0]}|${r2[1]}|g" "${KERNEL_DIR}/Makefile"
+      _check sed -ri "s|${r1[0]}|${r1[1]}|g" "${KERNEL_DIR}/Makefile"
+      _check sed -ri "s|${r2[0]}|${r2[1]}|g" "${KERNEL_DIR}/Makefile"
       if [[ $DEBUG == True ]]; then
         echo -e "\n${blue}${MSG_DEBUG_CC}$nc" >&2
         _get_cross_compile 1


### PR DESCRIPTION
Use of regex to match in case there is no space between variable name and equal sign.

Signed-off-by: grm34 <jerem.pardo@tutanota.com>